### PR TITLE
Fix #20: Correct project name shortening for names with dots

### DIFF
--- a/breadcrumb.el
+++ b/breadcrumb.el
@@ -354,7 +354,7 @@ propertized crumbs."
    finally
    (cl-return
     (if root
-        (cons (propertize (file-name-base (directory-file-name root))
+        (cons (propertize (file-name-nondirectory (directory-file-name root))
                           'bc-dont-shorten t
                           'face 'bc-project-base-face)
               retval)


### PR DESCRIPTION
"file-name-base" assumes the argument is a file name, so it will turn the folder "a.b" into "a"; therefore, use "file-name-nondirectory" to retrieve the name of the item, as it correctly handles periods.

This PR has been tested on my machine.