### PR TITLE
Fix autoloaded `register-definition-prefixes`

### DIFF
--- a/breadcrumb.el
+++ b/breadcrumb.el
@@ -436,8 +436,10 @@ propertized crumbs."
       (bc--goto (selected-window) choice))))
 
 (provide 'breadcrumb)
+;;;###autoload (register-definition-prefixes "breadcrumb" '("breadcrumb-"))
 ;;; breadcrumb.el ends here
 
 ;; Local Variables:
 ;; read-symbol-shorthands: (("bc-" . "breadcrumb-"))
+;; autoload-compute-prefixes: nil
 ;; End:

--- a/breadcrumb.el
+++ b/breadcrumb.el
@@ -437,9 +437,10 @@ propertized crumbs."
 
 (provide 'breadcrumb)
 ;;;###autoload (register-definition-prefixes "breadcrumb" '("breadcrumb-"))
-;;; breadcrumb.el ends here
 
 ;; Local Variables:
 ;; read-symbol-shorthands: (("bc-" . "breadcrumb-"))
 ;; autoload-compute-prefixes: nil
 ;; End:
+
+;;; breadcrumb.el ends here


### PR DESCRIPTION
Currently, autoload generation with shorthands results in:

`(register-definition-prefixes "breadcrumb" '("bc-"))`

The autoload prefix should be `"breadcrumb-"` so that `breadcrumb.el` will be autoloaded when users type in

`M-x describe-function RET breadcrumb-`

See `(info "(elisp)Autoload by Prefix")` for more information.

Related issues:

- https://github.com/joaotavora/breadcrumb/issues/3
- https://yhetil.org/emacs-bugs/sdvv8gwztqt.fsf@netyu.xyz/