### PR TITLE
fix: Prevent "args-out-of-range" error in breadcrumb summarization by…

### DIFF
--- a/breadcrumb.el
+++ b/breadcrumb.el
@@ -317,6 +317,7 @@ with SEPARATOR."
           for available = (- cutoff used)
           for (c . more) on (reverse crumbs)
           for seplen = (if more (length separator) 0)
+          when (and c (> (length c) 0))
           for shorten-p = (unless (get-text-property 0 'bc-dont-shorten c)
                             (> (+ (length c) seplen) available))
           for toadd = (if shorten-p (substring c 0 1) c)


### PR DESCRIPTION
Fixes this error:
```elisp
Debugger entered--Lisp error: (args-out-of-range "" 0 1)
breadcrumb--summarize((#("tmp.hkxABVyXv0" 0 14 (breadcrumb-dont-shorten t face breadcrumb-project-base-face)) "" #("home" 0 4 (face breadcrumb-project-crumbs-face breadcrumb-dont-shorten nil mouse-face header-line-highlight help-echo #("mouse-1: Go places near /sudo:root@s:/tmp/tmp.hkxABVyXv0//home/" 30 34 (tramp-default t) 35 36 (tramp-default t)) keymap (keymap (mode-line keymap (mouse-1 . #f(compiled-function (&rest event) ... #<bytecode -0x1bf83ea24bc7568f>))) (header-line keymap (mouse-1 . #f(compiled-function (&rest event) ... #<bytecode -0x1bf83ea24bc7568f>)))))) #("st" 0 2 (face breadcrumb-project-crumbs-face breadcrumb-dont-shorten nil mouse-face header-line-highlight help-echo #("mouse-1: Go places near /sudo:root@s:/tmp/tmp.hkxABVyXv0//home/st/" 30 34 (tramp-default t) 35 36 (tramp-default t)) keymap (keymap (mode-line keymap (mouse-1 . #f(compiled-function (&rest event) ... #<bytecode 0xe33dea052f9b4c0>))) (header-line keymap (mouse-1 . #f(compiled-function (&rest event) ... #<bytecode 0xe33dea052f9b4c0>)))))) #(".config" 0 7 (face breadcrumb-project-crumbs-face breadcrumb-dont-shorten nil mouse-face header-line-highlight help-echo #("mouse-1: Go places near /sudo:root@s:/tmp/tmp.hkxABVyXv0//home/st/.config/" 30 34 (tramp-default t) 35 36 (tramp-default t)) keymap (keymap (mode-line keymap (mouse-1 . #f(compiled-function (&rest event) ... #<bytecode -0xceb081976f4294d>))) (header-line keymap (mouse-1 . #f(compiled-function (&rest event) ... #<bytecode -0xceb081976f4294d>)))))) #("doom" 0 4 (face breadcrumb-project-crumbs-face breadcrumb-dont-shorten nil mouse-face header-line-highlight help-echo #("mouse-1: Go places near /sudo:root@s:/tmp/tmp.hkxABVyXv0//home/st/.config/doom/" 30 34 (tramp-default t) 35 36 (tramp-default t)) keymap (keymap (mode-line keymap (mouse-1 . #f(compiled-function (&rest event) ... #<bytecode -0x64806acbaf5e255>))) (header-line keymap (mouse-1 . #f(compiled-function (&rest event) ... #<bytecode -0x64806acbaf5e255>)))))) #("lisp" 0 4 (face breadcrumb-project-crumbs-face breadcrumb-dont-shorten nil mouse-face header-line-highlight help-echo #("mouse-1: Go places near /sudo:root@s:/tmp/tmp.hkxABVyXv0//home/st/.config/doom/lisp/" 30 34 (tramp-default t) 35 36 (tramp-default t)) keymap (keymap (mode-line keymap (mouse-1 . #f(compiled-function (&rest event) ... #<bytecode 0x438e16cbc8fda08>))) (header-line keymap (mouse-1 . #f(compiled-function (&rest event) ... #<bytecode 0x438e16cbc8fda08>)))))) #("cae-hacks.el" 0 12 (face breadcrumb-project-leaf-face breadcrumb-dont-shorten t mouse-face header-line-highlight help-echo #("mouse-1: Go places near /sudo:root@s:/tmp/tmp.hkxABVyXv0//home/st/.config/doom/lisp/cae-hacks.el" 30 34 (tramp-default t) 35 36 (tramp-default t)) keymap (keymap (mode-line keymap (mouse-1 . #f(compiled-function (&rest event) ... #<bytecode -0x181ae64e42551282>))) (header-line keymap (mouse-1 . #f(compiled-function (&rest event) ... #<bytecode -0x181ae64e42551282>))))))) 31.2 #("/" 0 1 (face breadcrumb-project-crumbs-face)))
breadcrumb-project-crumbs()
breadcrumb--turn-on-local-mode-on-behalf-of-global-mode()
breadcrumb-mode()
run-hooks(change-major-mode-after-body-hook prog-mode-hook lisp-data-mode-hook emacs-lisp-mode-hook)
apply(run-hooks change-major-mode-after-body-hook (prog-mode-hook lisp-data-mode-hook emacs-lisp-mode-hook))
run-mode-hooks(emacs-lisp-mode-hook)
emacs-lisp-mode()
funcall-interactively(emacs-lisp-mode)
command-execute(emacs-lisp-mode record)
execute-extended-command(nil "emacs-lisp-mode" nil)
funcall-interactively(execute-extended-command nil "emacs-lisp-mode" nil)
command-execute(execute-extended-command)
```