### PR TITLE
Improve header line redisplay performance

### DIFF
--- a/breadcrumb.el
+++ b/breadcrumb.el
@@ -344,13 +344,15 @@ to ROOT."
                   (define-key m bc--mode-line-key l)
                   m))))
 
+(defvar-local bc--project-root-cache nil
+  "A cache for `breadcrumb--project-crumbs-1'.")
+
 (defun bc--project-crumbs-1 (bfn)
   "Helper for `breadcrumb-project-crumbs'.
 Given BFN, the `buffer-file-name', produce a a list of
 propertized crumbs."
   (cl-loop
-   with project = (project-current)
-   with root = (if project (project-root project) default-directory)
+   with root = (or bc--project-root-cache default-directory)
    with relname = (file-relative-name (or bfn default-directory)
                                       root)
    for (s . more) on (split-string relname "/")
@@ -389,7 +391,11 @@ propertized crumbs."
 (define-minor-mode breadcrumb-local-mode
   "Header lines with breadcrumbs."
   :init-value nil
-  (if bc-local-mode (add-to-list 'header-line-format '(:eval (bc--header-line)))
+  (if bc-local-mode
+      (progn
+          (let ((project (project-current)))
+              (setq bc--project-root-cache (if project (project-root project) nil)))
+        (add-to-list 'header-line-format '(:eval (bc--header-line))))
     (setq header-line-format (delete '(:eval (bc--header-line)) header-line-format))))
 
 (defun bc--turn-on-local-mode-on-behalf-of-global-mode ()


### PR DESCRIPTION
I've noticed some performance issues with breadcrumb--header-line when opening larger files.

Steps to reproduce:
1. Open a go-ts-mode.el file
2. M-x breadcrumb-mode
3. Move cursor downward

Environment:
OS: macOS Sequoia 15.5 arm64
emacs-version: 31.0.50 (igc branch)
breadcrumb version: 1.0.1

CPU Profiler Report:

```
       23573  99% - redisplay_internal (C function)
       23207  97%  - eval
       23116  97%   - breadcrumb--header-line
       23113  97%    - mapcar
       23113  97%     - funcall
       23103  97%      - breadcrumb-project-crumbs
       23100  97%       - breadcrumb--project-crumbs-1
       23085  97%        - project-current
       23084  97%         - project--find-in-directory
       23084  97%          - run-hook-with-args-until-success
       22873  96%           - project-try-vc
       22873  96%            - project-try-vc--search
       22819  96%             - locate-dominating-file
       22806  96%              - #<byte-code-function AD2>
       22806  96%                 directory-files
          13   0%                abbreviate-file-name
          50   0%             + project--value-in-dir
           2   0%             + cl-find-if
         211   0%           + my/project-try-local
          13   0%          file-relative-name
           2   0%        + breadcrumb--format-project-node
           3   0%       + breadcrumb--summarize
          10   0%      + breadcrumb-imenu-crumbs
           3   0%      mapconcat
          41   0%   + doom-modeline-format--main
          19   0%   + doom-modeline-segment--buffer-info
          14   0%   + doom-modeline-segment--buffer-encoding
           8   0%   + doom-modeline-segment--major-mode
           2   0%   + doom-modeline-segment--irc
           2   0%   + doom-modeline-segment--buffer-position
           2   0%   + doom-modeline-segment--check
           2   0%   + doom-modeline-segment--modals
           1   0%   + doom-modeline-segment--debug
          33   0%  + jit-lock-function
           1   0%  + winum--update
           1   0%    mode-line-default-help-echo
         125   0% + timer-event-handler
           7   0% + command-execute
           1   0% + evil-repeat-post-hook
           1   0%   evil--jump-handle-buffer-crossing
           1   0%   which-key--hide-popup
           1   0% + evil-repeat-pre-hook
           0   0%   ...

```

I optimized this issue by adding a project root cache.
