### PR TITLE
Use project-name instead of root directory basename when available

### DIFF
--- a/breadcrumb.el
+++ b/breadcrumb.el
@@ -346,11 +346,12 @@ to ROOT."
 
 (defun bc--project-crumbs-1 (bfn)
   "Helper for `breadcrumb-project-crumbs'.
-Given BFN, the `buffer-file-name', produce a a list of
+Given BFN, the `buffer-file-name', produce a list of
 propertized crumbs."
   (cl-loop
    with project = (project-current)
    with root = (if project (project-root project) default-directory)
+   with project-name = (if project (project-name project) (file-name-nondirectory (directory-file-name root)))
    with relname = (file-relative-name (or bfn default-directory)
                                       root)
    for (s . more) on (split-string relname "/")
@@ -360,7 +361,7 @@ propertized crumbs."
    finally
    (cl-return
     (if root
-        (cons (propertize (file-name-nondirectory (directory-file-name root))
+        (cons (propertize project-name
                           'bc-dont-shorten t
                           'face 'bc-project-base-face)
               retval)


### PR DESCRIPTION
project-name's default implementation is equivalent to the previous
code, so no behavior change is expected unless the project type
overrides the project-name method.

At my site, we have a workflow where a monorepo is checked out at
various machine-readable but uninformative paths when working on
different branches of the code.  We override `project-name` to
display, effectively, the name of the branch rather than the repo's
root dir, and it would be great if breadcrumb.el could do the same.